### PR TITLE
Fix nerf gun secret from Arcane Alchemy

### DIFF
--- a/files/entities/nerf_gun/nerf_dart.xml
+++ b/files/entities/nerf_gun/nerf_dart.xml
@@ -67,7 +67,7 @@
   ></ItemComponent>
 
   	<LuaComponent 
-		script_item_picked_up="mods/arcane_alchemy/files/entities/nerf_gun/dart_pickup.lua" >
+		script_item_picked_up="mods/Hydroxide/files/entities/nerf_gun/dart_pickup.lua" >
 	</LuaComponent>
 
    <AudioComponent

--- a/files/scripts/append/append_actions.lua
+++ b/files/scripts/append/append_actions.lua
@@ -1,21 +1,20 @@
---[[
 table.insert( actions,
-{
-	id          = "ALCHEMY_NERF_DARTS",
-	name 		= "Nerf Darts",
-	description = "A collection of nerf darts for shooting purposes.",
-	sprite 		= "mods/Hydroxide/files/entities/nerf_gun/darts.png",
-	type 		= ACTION_TYPE_PROJECTILE,
-	spawn_level                       = "0,1,2,3,4,5,6,7", 
-	spawn_probability                 = "0,0,0,0,0,0,0,0",
-	price = 200000000,
-	mana = 0,
-	max_uses = 20,
-	action 		= function()
-		add_projectile("mods/Hydroxide/files/entities/nerf_gun/nerf_dart.xml")
-		c.speed_multiplier = 0.1
-		c.screenshake = c.screenshake + 20.0
-		shot_effects.recoil_knockback = shot_effects.recoil_knockback + 10
-	end,
-});
-]]--
+	{
+		id          = "ALCHEMY_NERF_DARTS",
+		name 		= "Nerf Darts",
+		description = "A collection of nerf darts for shooting purposes.",
+		sprite 		= "mods/Hydroxide/files/entities/nerf_gun/darts.png",
+		type 		= ACTION_TYPE_PROJECTILE,
+		spawn_level                       = "0,1,2,3,4,5,6,7", 
+		spawn_probability                 = "0,0,0,0,0,0,0,0",
+		price = 200000000,
+		mana = 0,
+		max_uses = 20,
+		action 		= function()
+			add_projectile("mods/Hydroxide/files/entities/nerf_gun/nerf_dart.xml")
+			c.speed_multiplier = 0.1
+			c.screenshake = c.screenshake + 20.0
+			shot_effects.recoil_knockback = shot_effects.recoil_knockback + 10
+		end,
+	})
+	

--- a/files/scripts/append/append_potion.lua
+++ b/files/scripts/append/append_potion.lua
@@ -179,7 +179,6 @@ table.insert(materials_magic, {
 
 local old_init = init
 init = function( entity_id )
-    GamePrint("Hydroxide init")
     roll_number = Random(1,100 * 1000) / 1000
     possible_rolls = {}
     for k, v in pairs(materials_magic)do

--- a/files/scripts/append/append_potion.lua
+++ b/files/scripts/append/append_potion.lua
@@ -179,6 +179,7 @@ table.insert(materials_magic, {
 
 local old_init = init
 init = function( entity_id )
+    GamePrint("Hydroxide init")
     roll_number = Random(1,100 * 1000) / 1000
     possible_rolls = {}
     for k, v in pairs(materials_magic)do

--- a/files/scripts/append/pixel_scenes/append_coalmine.lua
+++ b/files/scripts/append/pixel_scenes/append_coalmine.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+if ModSettingGet("Hydroxide.cc_pixelscenes") then
 table.insert(g_pixel_scene_01, {
 	prob			= 0.9,
 	material_file	= "mods/Hydroxide/files/pixel_scenes/coalmine/shrinekindling.png",
@@ -91,7 +91,7 @@ table.insert(g_oiltank, {
 
 end
 --[[ lanterns ]]--
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 table.insert(g_lamp, {
 	prob   		= 0.7,
 	min_count	= 1,

--- a/files/scripts/append/pixel_scenes/append_coalmine_alt.lua
+++ b/files/scripts/append/pixel_scenes/append_coalmine_alt.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 table.insert(g_props, {
 	prob		= 0.35,
 	min_count	= 1,

--- a/files/scripts/append/pixel_scenes/append_excavationsite.lua
+++ b/files/scripts/append/pixel_scenes/append_excavationsite.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+if ModSettingGet("Hydroxide.cc_pixelscenes") then
 table.insert(g_pixel_scene_04, {
 	prob			= 0.8,
 	material_file	= "mods/Hydroxide/files/pixel_scenes/excavationsite/excavationsite/blast_tank.png",
@@ -132,7 +132,7 @@ table.insert(g_gunpowderpool_04, {
 	});
 	
 end
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 table.insert(g_props, {
 	prob 		= 0.2,
 	min_count	= 1,

--- a/files/scripts/append/pixel_scenes/append_liquidcave.lua
+++ b/files/scripts/append/pixel_scenes/append_liquidcave.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+if ModSettingGet("Hydroxide.cc_pixelscenes") then
 table.insert(g_pixel_scene_01, {
 		prob   			= 1.2,
 		material_file 	= "data/biome_impl/liquidcave/container_01.png",

--- a/files/scripts/append/pixel_scenes/append_snowcastle.lua
+++ b/files/scripts/append/pixel_scenes/append_snowcastle.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+if ModSettingGet("Hydroxide.cc_pixelscenes") then
 table.insert(g_pixel_scene_01, {
 	prob			= 1.0,
 	material_file	= "mods/Hydroxide/files/pixel_scenes/snowcastle/alcohol_pipe.png",
@@ -31,7 +31,7 @@ table.insert(g_pixel_scene_02, {
 	is_unique		= 0
 	});
 end
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 	
 table.insert(g_props, {
 	prob		= 0.4,

--- a/files/scripts/append/pixel_scenes/append_snowcave.lua
+++ b/files/scripts/append/pixel_scenes/append_snowcave.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 table.insert(g_props, {
 	prob 		= 0.3,
 	min_count	= 1,

--- a/files/scripts/append/pixel_scenes/append_vault.lua
+++ b/files/scripts/append/pixel_scenes/append_vault.lua
@@ -1,4 +1,4 @@
-if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+if ModSettingGet("Hydroxide.cc_pixelscenes") then
 table.insert(g_pixel_scene_01, {
 	prob			= 1.0,
 	material_file	= "mods/Hydroxide/files/pixel_scenes/vault/hydroxidetank.png",
@@ -16,7 +16,7 @@ table.insert(g_pixel_scene_02, {
 	});
 end
 
-if ModSettingGet("Hydroxide.cc_props") == "on" then
+if ModSettingGet("Hydroxide.cc_props") then
 		
 	table.insert(g_props, {
 		prob 		= 0.5,

--- a/init.lua
+++ b/init.lua
@@ -37,7 +37,7 @@ function OnMagicNumbersAndWorldSeedInitialized() -- this is the last point where
 	print( "===================================== random " .. tostring(x) )
 	
 	
-	if ModSettingGet("Hydroxide.cc_ores") == "on" then 
+	if ModSettingGet("Hydroxide.cc_ores") then 
 	
 		if GameHasFlagRun("Squirrelly_Ore_generated") == false then
 			dofile_once("mods/Hydroxide/files/scripts/oreGen/inject_ores.lua")
@@ -113,7 +113,7 @@ register_translation("item_vial_with_material_description", "A glass vial contai
 ]]
 
 -- This code runs when all mods' filesystems are registered
-if ModSettingGet("Hydroxide.cc_spells") == "on" then 
+if ModSettingGet("Hydroxide.cc_spells") then 
 	ModLuaFileAppend( "data/scripts/gun/gun_actions.lua", "mods/Hydroxide/files/actions.lua" ) -- adds spells, really just sea of methane
 end
 
@@ -126,7 +126,7 @@ ModLuaFileAppend( "data/scripts/gun/gun_actions.lua", "mods/Hydroxide/files/scri
  
 ModLuaFileAppend( "data/scripts/status_effects/status_list.lua", "mods/Hydroxide/files/scripts/append/append_status_list.lua" ) --new status effects
 
-if ModSettingGet("Hydroxide.cc_flasks") == "on" then
+if ModSettingGet("Hydroxide.cc_flasks") then
 	ModLuaFileAppend( "data/scripts/items/potion.lua", "mods/Hydroxide/files/scripts/append/append_potion.lua" ) -- potions with new materials
 	ModLuaFileAppend( "data/scripts/items/powder_stash.lua", "mods/Hydroxide/files/scripts/append/append_powders.lua" ) -- powder bags spawn with new materials
 	ModLuaFileAppend( "data/scripts/items/potion_aggressive.lua", "mods/Hydroxide/files/scripts/append/append_potion_aggressive.lua" ) --for alchemist enemy
@@ -145,7 +145,7 @@ ModLuaFileAppend( "data/scripts/biomes/snowcastle.lua", "mods/Hydroxide/files/sc
 ModLuaFileAppend( "data/scripts/biomes/snowcave.lua", "mods/Hydroxide/files/scripts/append/pixel_scenes/append_snowcave.lua" ) --new structures in hiisi base
 ModLuaFileAppend( "data/scripts/biomes/vault.lua", "mods/Hydroxide/files/scripts/append/pixel_scenes/append_vault.lua" ) --new structures in the vault
 
-if ModSettingGet("Hydroxide.cc_items") == "on" then
+if ModSettingGet("Hydroxide.cc_items") then
 	ModLuaFileAppend( "data/scripts/item_spawnlists.lua", "mods/Hydroxide/files/scripts/append/append_items.lua" ) --adds items to pedestals
 end
 
@@ -195,7 +195,7 @@ function OnPlayerSpawned( player_entity ) -- This runs when player entity has be
     EntitySetDamageFromMaterial( player_entity, "hydroxide", 0.005 )
 	
 	  if GameHasFlagRun("squirrellys_music_altar_is_spawned") == false then  --Rename the flag to something unique, this checks if the game has this flag
-		if ModSettingGet("Hydroxide.cc_pixelscenes") == "on" then
+		if ModSettingGet("Hydroxide.cc_pixelscenes") then
 			EntityLoad("mods/Hydroxide/files/pixel_scenes/music_shrine.xml", 6200, 5500)  --load the musical shrine
 		end
 		

--- a/init.lua
+++ b/init.lua
@@ -122,7 +122,7 @@ ModMagicNumbersFileAdd( "mods/Hydroxide/files/magic_numbers.xml" ) -- Will overr
 --no idea what magic numbers are, but this does somethin to em
 
 
---ModLuaFileAppend( "data/scripts/gun/gun_actions.lua", "mods/Hydroxide/files/scripts/append/append_actions.lua") -- new spells ( deprecated )
+ModLuaFileAppend( "data/scripts/gun/gun_actions.lua", "mods/Hydroxide/files/scripts/append/append_actions.lua") -- Adds nerf dart spell, from Arcane Alchemy. For Magic Plastic secret.
  
 ModLuaFileAppend( "data/scripts/status_effects/status_list.lua", "mods/Hydroxide/files/scripts/append/append_status_list.lua" ) --new status effects
 


### PR DESCRIPTION
It did not work because you commented out the nerf dart spell.